### PR TITLE
Improve instructions for running the bot locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,20 @@ heroku config:add LUBOT_GITHUB="{\"Lullabot/lubot\": \"#bot\"}";
 Add the Heroku Scheduler app and add the command "rake dyno_ping" every 10 minutes to prevent your dyno from sleeping.
 
 ### Locally
-Set environment variables
+
+Install the required npm packages.
+
+```
+npm install
+```
+
+You'll also need to make sure MongoDB is running. If you've got it installed already you can run the following command which will start a mongodb server in the background.
+
+```
+mongod --fork --dbpath=./data/db --logpath ./data/logfile --logappend
+```
+
+Set the environment variables that the bot uses for configuration.
 
 ```
 export LUBOT_IRC_ROOMS="#room1,#room2"
@@ -47,10 +60,13 @@ export LUBOT_IRC_SERVER="holmes.freenode.net"
 export LUBOT_IRC_PORT=6697
 export LUBOT_IRC_NICK="lubot"
 export LUBOT_IRC_NICK_PW="password"
-export LUBOT_MONGODB="mongodb://<username>:<password>@<host>:<port>/<database>"
+# mongodb://<username>:<password>@<host>:<port>/<database>
+export LUBOT_MONGODB="mongodb://localhost/lubot"
 export LUBOT_MONGOPREFIX="lubot_"
 export LUBOT_GITHUB="{\"Lullabot/lubot\": \"#bot\"}";
 ```
+
+Finally, start up the bot.
 
 ```
 node lubot.js


### PR DESCRIPTION
Includes information about starting mongodb, and running `npm install` to get things all setup.

Also updates the example mongodb connection string variable to match what would work with the suggested command for starting mongodb.
