### PR TITLE
[#7] Allow factoids to be word case agnositc.

### DIFF
--- a/scripts/factoids.js
+++ b/scripts/factoids.js
@@ -26,7 +26,7 @@ module.exports = function(bot) {
       var re = /(.+?)\sis\s(.+)/;
       var matches = re.exec(text);
       if (!bot.helpers.utils.empty(matches, 1) && !bot.helpers.utils.empty(matches, 2)) {
-        bot.brain.upsertToCollection('factoids', {key: matches[1].toLowerCase(), channel: to}, {key: matches[1].toLowerCase(), channel: to, factoid: matches[2].toLowerCase()});
+        bot.brain.upsertToCollection('factoids', {key: matches[1].toLowerCase(), channel: to}, {key: matches[1].toLowerCase(), channel: to, factoid: matches[2]});
         bot.irc.say(to, nick + ': Okay!');
       }
     }

--- a/scripts/factoids.js
+++ b/scripts/factoids.js
@@ -26,7 +26,7 @@ module.exports = function(bot) {
       var re = /(.+?)\sis\s(.+)/;
       var matches = re.exec(text);
       if (!bot.helpers.utils.empty(matches, 1) && !bot.helpers.utils.empty(matches, 2)) {
-        bot.brain.upsertToCollection('factoids', {key: matches[1], channel: to}, {key: matches[1], channel: to, factoid: matches[2]});
+        bot.brain.upsertToCollection('factoids', {key: matches[1].toLowerCase(), channel: to}, {key: matches[1].toLowerCase(), channel: to, factoid: matches[2].toLowerCase()});
         bot.irc.say(to, nick + ': Okay!');
       }
     }
@@ -34,7 +34,7 @@ module.exports = function(bot) {
     // Delete a factoid.
     var delText = bot.helpers.utils.startsWith('delete factoid ', text);
     if (delText !== false) {
-      bot.brain.removeFromCollection('factoids', {key: delText, channel: to});
+      bot.brain.removeFromCollection('factoids', {key: delText.toLowerCase(), channel: to});
       bot.irc.say(to, nick + ': Okay!');
     }
 
@@ -48,7 +48,7 @@ module.exports = function(bot) {
       factoid = bot.helpers.utils.endsWith('!', factoid);
     }
     if (factoid !== false) {
-      bot.brain.loadFromCollection('factoids', {key: factoid, channel: to}, {}, function(docs) {
+      bot.brain.loadFromCollection('factoids', {key: factoid.toLowerCase(), channel: to}, {}, function(docs) {
         if (docs.hasOwnProperty(0)) {
           bot.irc.say(to, factoid + ' is ' + docs[0].factoid);
         }


### PR DESCRIPTION
Allows for factoids to not care about case, as per #7.

Example:

```
[21:36:22] <@eojthebrave>   lubot: joe is awesome
[21:36:22] <lubot>  eojthebrave: Okay!
[21:36:25] <@eojthebrave>   Joe?
[21:36:25] <lubot>  Joe is awesome
[21:36:28] <@eojthebrave>   Joe!
[21:36:28] <lubot>  Joe is awesome
[21:36:32] <@eojthebrave>   joe!
[21:36:32] <lubot>  joe is awesome
[21:36:49] <@eojthebrave>   JOE?
[21:36:50] <lubot>  JOE is awesome
[21:36:52] <@eojthebrave>   joE
[21:36:59] <@eojthebrave>   delete factoid JoE
[21:36:59] <lubot>  eojthebrave: Okay!
[21:37:02] <@eojthebrave>   joe?
```

Resolves #7
