### PR TITLE
[#23] Requests to retreive an objects karma should always end with a "?"

### DIFF
--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -41,16 +41,16 @@ module.exports = function(bot) {
       var removeQM = bot.helpers.utils.endsWith('?', cutText);
       if (removeQM !== false) {
         cutText = removeQM;
-      }
 
-      bot.brain.loadFromCollection('karma', {key: cutText, channel: to}, {}, function(docs) {
-        if (bot.helpers.utils.empty(docs, 0)) {
-          bot.irc.say(to, cutText + ' has a karma of 0');
-        }
-        else {
-          bot.irc.say(to, cutText + ' has a karma of ' + docs[0].value);
-        }
-      });
+        bot.brain.loadFromCollection('karma', {key: cutText, channel: to}, {}, function(docs) {
+          if (bot.helpers.utils.empty(docs, 0)) {
+            bot.irc.say(to, cutText + ' has a karma of 0');
+          }
+          else {
+            bot.irc.say(to, cutText + ' has a karma of ' + docs[0].value);
+          }
+        });
+      }
     }
   });
 };


### PR DESCRIPTION
This makes sure that any request to retrieve the karma of an object ends with a  question mark.

`karma joe?` will work, `karma joe` will not.

Resolves #23.
