### PR TITLE
Slackbot regex

### DIFF
--- a/lubot.js
+++ b/lubot.js
@@ -169,7 +169,7 @@ bot.helpers.utils = {
     return bot.helpers.utils.stripKarma(text, 'down');
   },
   stripKarma: function(text, direction) {
-    var re = new RegExp('^(.+)(?=[ >:]*' + (direction === 'down' ? '--' : '\\+\\+') + ')', 'i'),
+    var re = new RegExp('^(.+)(?=[ >:]*' + (direction === 'down' ? '--' : '\\+\\+') + '$)', 'i'),
       matches,
       ret = false;
 
@@ -185,6 +185,12 @@ bot.helpers.utils = {
       // Special case for user status with "|" character.
       else if (matches = ret.match(/^(.+)\|.+/i)) {
         ret = matches[1];
+      }
+
+      // Ignore any matches greater than 34 chars, this is aribitrary, existing
+      // DB has entries up to 34 chars in length, so 34 seems reasonable
+      if (ret.length > 34) {
+        ret = false;
       }
     }
     return ret;

--- a/lubot.js
+++ b/lubot.js
@@ -163,23 +163,34 @@ bot.helpers.utils = {
     return false;
   },
   stripUpKarma: function(text) {
-    var re = new RegExp("([A-Za-z0-9]{1,})(?=[ >:]*\\+\\+)");
-    var matches = re.exec(text);
-    if (matches) {
-      return(matches[1]);
-    }
-    return false;
+    return bot.helpers.utils.stripKarma(text, 'up');
   },
   stripDownKarma: function(text) {
-    var re = new RegExp("([A-Za-z0-9]{1,})(?=[ >:]*\-\-)");
-    var matches = re.exec(text);
+    return bot.helpers.utils.stripKarma(text, 'down');
+  },
+  stripKarma: function(text, direction) {
+    var re = new RegExp('^(.+)(?=[ >:]*' + (direction === 'down' ? '--' : '\\+\\+') + ')', 'i'),
+      matches,
+      ret = false;
+
+    text = text.replace(/^\s+|\s+$/, '');
+    matches = re.exec(text);
     if (matches) {
-      return(matches[1]);
+      ret = matches[1];
+      // Furthur processing.
+      // Special case for user away name, eg. [tlattimore]
+      if (matches = ret.match(/^\[(.+)]/i)) {
+        ret = matches[1];
+      }
+      // Special case for user status with "|" character.
+      else if (matches = ret.match(/^(.+)\|.+/i)) {
+        ret = matches[1];
+      }
     }
-    return false;
+    return ret;
   },
   slackUserStrip: function(text) {
-    var re = new RegExp("([A-Za-z0-9]{1,})");
+    var re = new RegExp("([-._a-z0-9]+)", "i");
     var matches = re.exec(text);
     if (matches) {
       return(matches[1]);

--- a/lubot.js
+++ b/lubot.js
@@ -169,10 +169,23 @@ bot.helpers.utils = {
     return bot.helpers.utils.stripKarma(text, 'down');
   },
   stripKarma: function(text, direction) {
-    var re = new RegExp('^(.+)(?=[ >:]*' + (direction === 'down' ? '--' : '\\+\\+') + '$)', 'i'),
+    // So this crazy regex will..
+    // - Match the beggining of the string
+    // - Ignore any leading @
+    // - Match what follows up to, but not including an optional trailing space,
+    //   ">", or ":" ending with a "++" or "--"
+    // - Note that the first capturing group captures non-greedy, so that it
+    //   doesn't consume any extra "+" or "-" that may be part of the text,
+    //   eg. in q0rban++++++++, the first capture group will only take q0rban.
+    //   This leaves any "+" or "-" for the lookahead to match, and thus capture
+    //   the text we care about, while ignoring the superfluous "+" and "-".
+    var f = require('util').format,
+      modifier = (direction == 'down' ? '-' : '\\+'),
+      re = new RegExp(f('^@?(.+?)(?=[ >:]*%s{2,}$)', modifier)),
       matches,
       ret = false;
 
+    // Ignore any leading or trailing space
     text = text.replace(/^\s+|\s+$/, '');
     matches = re.exec(text);
     if (matches) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "node-slack": "0.0.5",
     "slack-node": "^0.1.3",
     "ws": "^0.7.2",
-    "node-yaml-config": "0.0.3"
+    "node-yaml-config": "0.0.3",
+    "util": "^0.10.3"
   },
   "engines": {
     "node": ">= 0.8.x",


### PR DESCRIPTION
Resolves #48 

cc @willwh @q0rban

Some notes:
- Matches any line that ends with ++/--, ignoring leading or trailing whitespace
- Ignores lines with char length > 34 chars.  I picked that based on the longest char in the current database.
- Ignores ++/-- in the middle of a sentence, eg. `we don't want $i++ to increment a karma value for i`
- Tries to resolve user names of the form `tlattimore|afk++` or `[tlattimore]++`, even though we probably don't need these anymore with Slack.
